### PR TITLE
Deploy MkDocs site to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,55 @@
+name: Deploy docs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docs/**
+      - tools/**
+      - scripts/cuvis_sdk_url.py
+      - mkdocs.yml
+      - pyproject.toml
+      - uv.lock
+      - .github/workflows/deploy-docs.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Sync docs deps
+        run: uv sync --extra docs
+
+      - name: Build site
+        run: uv run mkdocs build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Cuvis SDK
 site_description: Cubert hyperspectral camera SDK — installers, wrappers, examples.
+site_url: https://cubert-hyperspectral.github.io/cuvis.sdk/
 repo_url: https://github.com/cubert-hyperspectral/cuvis.sdk
 edit_uri: blob/main/docs/
 


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds the MkDocs site and publishes it to GitHub Pages on every push to `main`, plus the `site_url` Material needs for correct sitemap and OG/canonical links.

- `.github/workflows/deploy-docs.yml` — two-job pipeline:
  1. **build**: `actions/checkout@v4` → `astral-sh/setup-uv@v4` (with cache) → `uv sync --extra docs` → `uv run mkdocs build --strict` → `actions/upload-pages-artifact@v3`.
  2. **deploy**: `actions/deploy-pages@v4` against the `github-pages` environment.
- Path-filtered triggers (`docs/**`, `tools/**`, `scripts/cuvis_sdk_url.py`, `mkdocs.yml`, `pyproject.toml`, `uv.lock`, the workflow itself) plus `workflow_dispatch` for manual redeploys.
- `pages` concurrency group so two deploys can't race.
- `mkdocs.yml`: adds `site_url: https://cubert-hyperspectral.github.io/cuvis.sdk/`.

The macros build queries `api.github.com/.../releases` unauthenticated (the helper script doesn't read `GITHUB_TOKEN`); 60 req/hr is plenty for a docs build with ~5 release queries, and the macros already wrap the call in a try/except that falls back to a static "browse all releases" link if the API ever errors.

## To enable Pages after merge

1. Repo **Settings → Pages → Build and deployment → Source** → "GitHub Actions".
2. Either push any docs change to `main` or run **Actions → Deploy docs to GitHub Pages → Run workflow** manually.
3. Site goes live at https://cubert-hyperspectral.github.io/cuvis.sdk/.

A custom subdomain can be added later by dropping a `CNAME` file in `docs/` (or via Settings → Pages → Custom domain) — out of scope for this PR.

## Test plan

- [x] `uv run mkdocs build --strict` builds clean locally with the new `site_url` (no warnings, sitemap.xml carries the absolute URLs).
- [ ] After merge, the `Deploy docs to GitHub Pages` workflow runs, both jobs go green, and the `github-pages` environment shows the deployment URL.
- [ ] https://cubert-hyperspectral.github.io/cuvis.sdk/ serves the rendered installation selector.
- [ ] Manual `gh workflow run deploy-docs.yml` redeploys without changes.
